### PR TITLE
Add Vite Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1394,6 +1394,48 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
+      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.18.6.tgz",
@@ -1978,6 +2020,141 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+      "integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
@@ -1988,6 +2165,171 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -4171,12 +4513,20 @@
         "@pixi/utils": "6.5.8"
       }
     },
+    "node_modules/@pixi/storybook-preset-vite": {
+      "resolved": "packages/storybook-preset-vite",
+      "link": true
+    },
     "node_modules/@pixi/storybook-preset-webpack": {
       "resolved": "packages/storybook-preset-webpack",
       "link": true
     },
     "node_modules/@pixi/storybook-renderer": {
       "resolved": "packages/storybook-renderer",
+      "link": true
+    },
+    "node_modules/@pixi/storybook-vite": {
+      "resolved": "packages/storybook-vite",
       "link": true
     },
     "node_modules/@pixi/storybook-webpack5": {
@@ -4262,6 +4612,32 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "5.3.0",
@@ -5809,6 +6185,114 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/preview": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.0-beta.2.tgz",
+      "integrity": "sha512-M8gvh7E2VC1dAWuQXdwUQPb89UQaa6PrClmYM4/Aa/mz+SevnAvycmkXzszXf6CMaUAo/wqymyEc4jd9ARXDpQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.0-beta.2.tgz",
+      "integrity": "sha512-c0lXWUxWygqI4Roi+57fMsXab/D1uHKN5pQa66CwflIa41jKJjYGgJrd7RAX3ScSOqZzEk11iwLnZVKkROph/w==",
+      "dependencies": {
+        "@storybook/channel-postmessage": "7.0.0-beta.2",
+        "@storybook/channels": "7.0.0-beta.2",
+        "@storybook/client-logger": "7.0.0-beta.2",
+        "@storybook/core-events": "7.0.0-beta.2",
+        "@storybook/csf": "next",
+        "@storybook/types": "7.0.0-beta.2",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "slash": "^3.0.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/@storybook/channel-postmessage": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.0-beta.2.tgz",
+      "integrity": "sha512-a2BkF/4oQ3R+9IfrSjEFvMB91bdISuX/cFEjDMhkAsCSPTInF+8tL3lPi8UT9idLt4lBesoGzP3zkDJHHfYQuA==",
+      "dependencies": {
+        "@storybook/channels": "7.0.0-beta.2",
+        "@storybook/client-logger": "7.0.0-beta.2",
+        "@storybook/core-events": "7.0.0-beta.2",
+        "global": "^4.4.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/@storybook/channels": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-beta.2.tgz",
+      "integrity": "sha512-W+kOLjetkfNPpozdE3OXRUp+aKbCJ2t9dIbSked7BOlOtAtKKfQ8F/b12ugGGLpVqo19GdgMPEILOswmeZANIg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/@storybook/client-logger": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-beta.2.tgz",
+      "integrity": "sha512-6muyKykkS/1G4j7hpnIj0JjubXK9EGxyeqJNEA7dfBWGfJsBzhxISGnaLuAmrG/+RQgjUaGySEVLFxadMrl+DQ==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/@storybook/core-events": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.0-beta.2.tgz",
+      "integrity": "sha512-vA8wuKM2f4A5daannTjiyPCG4vU3zK/VC7HSgL9/gwpzIzDFbQfFYQYTsj5uZN27jPTybys6L62Sw3L0Kpaaig==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/@storybook/types": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-beta.2.tgz",
+      "integrity": "sha512-pNdg0QYSX2UVjAhq5y//vL745wz7qwKX2v2TF17fONvVeO9DPNy7lWUKTG2d7yGWaSb9Nl9jsqi2RWMq8eTDmQ==",
+      "dependencies": {
+        "@babel/core": "^7.12.10",
+        "@storybook/channels": "7.0.0-beta.2",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "express": "^4.17.3",
+        "file-system-cache": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/preview-api/node_modules/telejson": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.0.4.tgz",
+      "integrity": "sha512-J4QEuCnYGXAI9KSN7RXK0a0cOW2ONpjc4IQbInGZ6c3stvplLAYyZjTnScrRd8deXVjNCFV1wXcLC7SObDuQYA==",
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      }
+    },
     "node_modules/@storybook/preview-web": {
       "version": "7.0.0-alpha.48",
       "resolved": "https://registry.npmjs.org/@storybook/preview-web/-/preview-web-7.0.0-alpha.48.tgz",
@@ -6180,6 +6664,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -6272,7 +6765,6 @@
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -11220,6 +11712,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
+      "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
+      "dependencies": {
+        "@types/glob": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/ahmadnassri"
+      },
+      "peerDependencies": {
+        "glob": "^7.1.6"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -13418,6 +13928,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -16868,6 +17389,14 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "dev": true,
@@ -17563,9 +18092,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
+      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17575,6 +18104,20 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-external-globals": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.7.1.tgz",
+      "integrity": "sha512-3U2OBhCa/D57P2SA9fx1CGS1xi9h7x7L3+nnAJ0563nIucQysHQdebfKYoI+2WZVkRdVuZKh4M+rgoF0B5W9Ag==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.2",
+        "estree-walker": "^3.0.1",
+        "is-reference": "^3.0.0",
+        "magic-string": "^0.26.7"
+      },
+      "peerDependencies": {
+        "rollup": "^2.25.0 || ^3.3.0"
       }
     },
     "node_modules/rsvp": {
@@ -18481,6 +19024,12 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
     "node_modules/space-separated-tokens": {
       "version": "1.1.5",
@@ -20232,6 +20781,120 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
+      "integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
+      "dependencies": {
+        "esbuild": "^0.16.3",
+        "postcss": "^8.4.19",
+        "resolve": "^1.22.1",
+        "rollup": "^3.7.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+      "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+      "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+      "integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.16.3",
+        "@esbuild/android-arm64": "0.16.3",
+        "@esbuild/android-x64": "0.16.3",
+        "@esbuild/darwin-arm64": "0.16.3",
+        "@esbuild/darwin-x64": "0.16.3",
+        "@esbuild/freebsd-arm64": "0.16.3",
+        "@esbuild/freebsd-x64": "0.16.3",
+        "@esbuild/linux-arm": "0.16.3",
+        "@esbuild/linux-arm64": "0.16.3",
+        "@esbuild/linux-ia32": "0.16.3",
+        "@esbuild/linux-loong64": "0.16.3",
+        "@esbuild/linux-mips64el": "0.16.3",
+        "@esbuild/linux-ppc64": "0.16.3",
+        "@esbuild/linux-riscv64": "0.16.3",
+        "@esbuild/linux-s390x": "0.16.3",
+        "@esbuild/linux-x64": "0.16.3",
+        "@esbuild/netbsd-x64": "0.16.3",
+        "@esbuild/openbsd-x64": "0.16.3",
+        "@esbuild/sunos-x64": "0.16.3",
+        "@esbuild/win32-arm64": "0.16.3",
+        "@esbuild/win32-ia32": "0.16.3",
+        "@esbuild/win32-x64": "0.16.3"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
       "dev": true,
@@ -20801,6 +21464,31 @@
         "storybook": "7.0.0-alpha.48"
       }
     },
+    "packages/storybook-preset-vite": {
+      "name": "@pixi/storybook-preset-vite",
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^16.0.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "vite": "4"
+      },
+      "devDependencies": {
+        "typescript": "~4.6.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "packages/storybook-preset-vite/node_modules/@types/node": {
+      "version": "16.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.7.tgz",
+      "integrity": "sha512-SghuoXv8ghvkrKjTyvhRTeNzivPzGQ8pe09PPGdyqsExiKvBYV/6E3imvjsaJuW8ca61qQN2+SoSzyEHS9r2LA=="
+    },
     "packages/storybook-preset-webpack": {
       "name": "@pixi/storybook-preset-webpack",
       "version": "0.0.2",
@@ -20854,6 +21542,484 @@
       },
       "peerDependencies": {
         "@babel/core": "*"
+      }
+    },
+    "packages/storybook-vite": {
+      "name": "@pixi/storybook-vite",
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/storybook-preset-vite": "^0.0.2",
+        "@pixi/storybook-renderer": "^0.0.2",
+        "@storybook/builder-vite": "^7.0.0-beta.2",
+        "@storybook/core-common": "7.0.0-alpha.48",
+        "@types/node": "^14.14.20 || ^16.0.0",
+        "@types/offscreencanvas": "^2019.7.0",
+        "global": "^4.4.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
+      },
+      "devDependencies": {
+        "typescript": "~4.6.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "packages/storybook-vite/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/builder-vite": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.0.0-beta.2.tgz",
+      "integrity": "sha512-OfPWLHnoei1qiclBj8C103TtKVVFewGjU79q49KHiqg5So+CNl2sy5gcUPn2Z+H6/1uU15vk7nYAme3HRH/cpQ==",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.5",
+        "@storybook/client-logger": "7.0.0-beta.2",
+        "@storybook/core-common": "7.0.0-beta.2",
+        "@storybook/csf-plugin": "7.0.0-beta.2",
+        "@storybook/mdx2-csf": "next",
+        "@storybook/node-logger": "7.0.0-beta.2",
+        "@storybook/preview": "7.0.0-beta.2",
+        "@storybook/preview-api": "7.0.0-beta.2",
+        "@storybook/types": "7.0.0-beta.2",
+        "@vitejs/plugin-react": "^2.0.0",
+        "browser-assert": "^1.2.1",
+        "es-module-lexer": "^0.9.3",
+        "express": "^4.17.3",
+        "fs-extra": "^9.0.1",
+        "glob": "^7.2.0",
+        "glob-promise": "^4.2.0",
+        "magic-string": "^0.26.1",
+        "rollup": "^2.25.0 || ^3.3.0",
+        "rollup-plugin-external-globals": "^0.7.1",
+        "slash": "^3.0.0",
+        "vite": "^3.0.0||^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@preact/preset-vite": "*",
+        "vite-plugin-glimmerx": "*"
+      },
+      "peerDependenciesMeta": {
+        "@preact/preset-vite": {
+          "optional": true
+        },
+        "vite-plugin-glimmerx": {
+          "optional": true
+        }
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/builder-vite/node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.0.5.tgz",
+      "integrity": "sha512-HwAEj/vAP1+hzBfIv9DTCyg+1O0/LG48Up7j1RmJ+pFwjb/wRxzUBco4LqKFKe7SZ0M6IyASNh1oKP3yHnJElA==",
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
+        "glob": "^7.2.0",
+        "glob-promise": "^4.2.0",
+        "magic-string": "^0.26.1",
+        "react-docgen-typescript": "^2.1.1"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": ">2.0.0-0"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/builder-vite/node_modules/@storybook/core-common": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.0-beta.2.tgz",
+      "integrity": "sha512-Ej7WjXIn4QHLGGx2Cj/QORtYeMyHzTc3NTkp0LlZFtLC2YXUEu5SUISecl/sJ1nYhsxm9mAPMtwMvbi9MMgPKg==",
+      "dependencies": {
+        "@babel/core": "^7.20.2",
+        "@storybook/node-logger": "7.0.0-beta.2",
+        "@storybook/types": "7.0.0-beta.2",
+        "@types/babel__core": "^7.1.20",
+        "@types/express": "^4.7.0",
+        "@types/node": "^16.0.0",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.14.48",
+        "esbuild-register": "^3.3.3",
+        "express": "^4.17.3",
+        "file-system-cache": "^2.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^9.0.1",
+        "glob": "^7.1.6",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^3.0.1",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "slash": "^3.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/builder-vite/node_modules/esbuild": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/builder-vite/node_modules/react-docgen-typescript": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+      "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/channels": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-beta.2.tgz",
+      "integrity": "sha512-W+kOLjetkfNPpozdE3OXRUp+aKbCJ2t9dIbSked7BOlOtAtKKfQ8F/b12ugGGLpVqo19GdgMPEILOswmeZANIg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/client-logger": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-beta.2.tgz",
+      "integrity": "sha512-6muyKykkS/1G4j7hpnIj0JjubXK9EGxyeqJNEA7dfBWGfJsBzhxISGnaLuAmrG/+RQgjUaGySEVLFxadMrl+DQ==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/csf-plugin": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-7.0.0-beta.2.tgz",
+      "integrity": "sha512-tAM7gDjl+y3FrqC4rFFsJGEmks12T5BKj63+CMXebydOAsBh67ebc82a+zquG8pRTXVf/qPEeHuf9mNR3+ekzA==",
+      "dependencies": {
+        "@storybook/csf-tools": "7.0.0-beta.2",
+        "unplugin": "^0.10.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/csf-tools": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.0-beta.2.tgz",
+      "integrity": "sha512-e7qWl1VRy/02o9FmDt8kUg+XTY32pzxs9WFgdhG6gT2tKm5sUPr0UjJr8dab7tC+wH9zBZYNTQgNKPHhKQ0CPQ==",
+      "dependencies": {
+        "@babel/types": "^7.20.2",
+        "@storybook/csf": "next",
+        "@storybook/types": "7.0.0-beta.2",
+        "fs-extra": "^9.0.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/node-logger": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.0-beta.2.tgz",
+      "integrity": "sha512-8Gl0cRN8stOa0TvQRH33kfYUC3NfBFogi/VmuJMJKkeYhU9WSvHVc3QvpxoE/ezYVk4D9ECkaaUlVrKpQdh8gQ==",
+      "dependencies": {
+        "@types/npmlog": "^4.1.2",
+        "chalk": "^4.1.0",
+        "npmlog": "^5.0.1",
+        "pretty-hrtime": "^1.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@storybook/types": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-beta.2.tgz",
+      "integrity": "sha512-pNdg0QYSX2UVjAhq5y//vL745wz7qwKX2v2TF17fONvVeO9DPNy7lWUKTG2d7yGWaSb9Nl9jsqi2RWMq8eTDmQ==",
+      "dependencies": {
+        "@babel/core": "^7.12.10",
+        "@storybook/channels": "7.0.0-beta.2",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "express": "^4.17.3",
+        "file-system-cache": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/storybook-vite/node_modules/@types/node": {
+      "version": "16.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.7.tgz",
+      "integrity": "sha512-SghuoXv8ghvkrKjTyvhRTeNzivPzGQ8pe09PPGdyqsExiKvBYV/6E3imvjsaJuW8ca61qQN2+SoSzyEHS9r2LA=="
+    },
+    "packages/storybook-vite/node_modules/@vitejs/plugin-react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
+      "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
+      "dependencies": {
+        "@babel/core": "^7.19.6",
+        "@babel/plugin-transform-react-jsx": "^7.19.0",
+        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.26.7",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0"
+      }
+    },
+    "packages/storybook-vite/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/storybook-vite/node_modules/esbuild-darwin-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/storybook-vite/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "packages/storybook-vite/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/storybook-vite/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/storybook-vite/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/storybook-vite/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "packages/storybook-vite/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/storybook-vite/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/storybook-vite/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/storybook-vite/node_modules/rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "packages/storybook-vite/node_modules/vite": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
+      "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+      "dependencies": {
+        "esbuild": "^0.15.9",
+        "postcss": "^8.4.18",
+        "resolve": "^1.22.1",
+        "rollup": "^2.79.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "packages/storybook-webpack5": {
@@ -21786,6 +22952,30 @@
         "@babel/types": "^7.19.0"
       }
     },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
+      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.18.6.tgz",
@@ -22219,10 +23409,130 @@
       "integrity": "sha512-+Rb20XXxRGisNu2WmNKk+scpanb7nL5yhuI1KR9wQFiC43ddPj/V1fmNyzlFC9bKiG4mYzxW7egtoHVcynr+OA==",
       "optional": true
     },
+    "@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+      "integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "optional": true
+    },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
       "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
       "optional": true
     },
     "@fal-works/esbuild-plugin-global-externals": {
@@ -23763,6 +25073,23 @@
       "integrity": "sha512-WiJd4fKpSitD3A+/u5q8IPoHXMFT8++bsluhuJvDwzo//s0PHb9qExlF2xos7zUmekmydEFMkDnrl4+lWn2cyg==",
       "requires": {}
     },
+    "@pixi/storybook-preset-vite": {
+      "version": "file:packages/storybook-preset-vite",
+      "requires": {
+        "@types/node": "^16.0.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "typescript": "~4.6.3",
+        "vite": "4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.7.tgz",
+          "integrity": "sha512-SghuoXv8ghvkrKjTyvhRTeNzivPzGQ8pe09PPGdyqsExiKvBYV/6E3imvjsaJuW8ca61qQN2+SoSzyEHS9r2LA=="
+        }
+      }
+    },
     "@pixi/storybook-preset-webpack": {
       "version": "file:packages/storybook-preset-webpack",
       "requires": {
@@ -23798,6 +25125,323 @@
         "react-dom": "16.14.0",
         "ts-dedent": "^2.0.0",
         "typescript": "~4.6.3"
+      }
+    },
+    "@pixi/storybook-vite": {
+      "version": "file:packages/storybook-vite",
+      "requires": {
+        "@pixi/storybook-preset-vite": "^0.0.2",
+        "@pixi/storybook-renderer": "^0.0.2",
+        "@storybook/builder-vite": "^7.0.0-beta.2",
+        "@storybook/core-common": "7.0.0-alpha.48",
+        "@types/node": "^14.14.20 || ^16.0.0",
+        "@types/offscreencanvas": "^2019.7.0",
+        "global": "^4.4.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "typescript": "~4.6.3"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@storybook/builder-vite": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.0.0-beta.2.tgz",
+          "integrity": "sha512-OfPWLHnoei1qiclBj8C103TtKVVFewGjU79q49KHiqg5So+CNl2sy5gcUPn2Z+H6/1uU15vk7nYAme3HRH/cpQ==",
+          "requires": {
+            "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.5",
+            "@storybook/client-logger": "7.0.0-beta.2",
+            "@storybook/core-common": "7.0.0-beta.2",
+            "@storybook/csf-plugin": "7.0.0-beta.2",
+            "@storybook/mdx2-csf": "next",
+            "@storybook/node-logger": "7.0.0-beta.2",
+            "@storybook/preview": "7.0.0-beta.2",
+            "@storybook/preview-api": "7.0.0-beta.2",
+            "@storybook/types": "7.0.0-beta.2",
+            "@vitejs/plugin-react": "^2.0.0",
+            "browser-assert": "^1.2.1",
+            "es-module-lexer": "^0.9.3",
+            "express": "^4.17.3",
+            "fs-extra": "^9.0.1",
+            "glob": "^7.2.0",
+            "glob-promise": "^4.2.0",
+            "magic-string": "^0.26.1",
+            "rollup": "^2.25.0 || ^3.3.0",
+            "rollup-plugin-external-globals": "^0.7.1",
+            "slash": "^3.0.0",
+            "vite": "^3.0.0||^4.0.0"
+          },
+          "dependencies": {
+            "@joshwooding/vite-plugin-react-docgen-typescript": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.0.5.tgz",
+              "integrity": "sha512-HwAEj/vAP1+hzBfIv9DTCyg+1O0/LG48Up7j1RmJ+pFwjb/wRxzUBco4LqKFKe7SZ0M6IyASNh1oKP3yHnJElA==",
+              "requires": {
+                "@rollup/pluginutils": "^4.2.1",
+                "glob": "^7.2.0",
+                "glob-promise": "^4.2.0",
+                "magic-string": "^0.26.1",
+                "react-docgen-typescript": "^2.1.1"
+              }
+            },
+            "@storybook/core-common": {
+              "version": "7.0.0-beta.2",
+              "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.0-beta.2.tgz",
+              "integrity": "sha512-Ej7WjXIn4QHLGGx2Cj/QORtYeMyHzTc3NTkp0LlZFtLC2YXUEu5SUISecl/sJ1nYhsxm9mAPMtwMvbi9MMgPKg==",
+              "requires": {
+                "@babel/core": "^7.20.2",
+                "@storybook/node-logger": "7.0.0-beta.2",
+                "@storybook/types": "7.0.0-beta.2",
+                "@types/babel__core": "^7.1.20",
+                "@types/express": "^4.7.0",
+                "@types/node": "^16.0.0",
+                "@types/pretty-hrtime": "^1.0.0",
+                "chalk": "^4.1.0",
+                "esbuild": "^0.14.48",
+                "esbuild-register": "^3.3.3",
+                "express": "^4.17.3",
+                "file-system-cache": "^2.0.0",
+                "find-up": "^5.0.0",
+                "fs-extra": "^9.0.1",
+                "glob": "^7.1.6",
+                "handlebars": "^4.7.7",
+                "lazy-universal-dotenv": "^3.0.1",
+                "picomatch": "^2.3.0",
+                "pkg-dir": "^5.0.0",
+                "pretty-hrtime": "^1.0.3",
+                "resolve-from": "^5.0.0",
+                "slash": "^3.0.0",
+                "ts-dedent": "^2.0.0"
+              }
+            },
+            "esbuild": {
+              "version": "0.14.54",
+              "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+              "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+              "requires": {
+                "@esbuild/linux-loong64": "0.14.54",
+                "esbuild-android-64": "0.14.54",
+                "esbuild-android-arm64": "0.14.54",
+                "esbuild-darwin-64": "0.14.54",
+                "esbuild-darwin-arm64": "0.14.54",
+                "esbuild-freebsd-64": "0.14.54",
+                "esbuild-freebsd-arm64": "0.14.54",
+                "esbuild-linux-32": "0.14.54",
+                "esbuild-linux-64": "0.14.54",
+                "esbuild-linux-arm": "0.14.54",
+                "esbuild-linux-arm64": "0.14.54",
+                "esbuild-linux-mips64le": "0.14.54",
+                "esbuild-linux-ppc64le": "0.14.54",
+                "esbuild-linux-riscv64": "0.14.54",
+                "esbuild-linux-s390x": "0.14.54",
+                "esbuild-netbsd-64": "0.14.54",
+                "esbuild-openbsd-64": "0.14.54",
+                "esbuild-sunos-64": "0.14.54",
+                "esbuild-windows-32": "0.14.54",
+                "esbuild-windows-64": "0.14.54",
+                "esbuild-windows-arm64": "0.14.54"
+              }
+            },
+            "react-docgen-typescript": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+              "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+              "requires": {}
+            }
+          }
+        },
+        "@storybook/channels": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-beta.2.tgz",
+          "integrity": "sha512-W+kOLjetkfNPpozdE3OXRUp+aKbCJ2t9dIbSked7BOlOtAtKKfQ8F/b12ugGGLpVqo19GdgMPEILOswmeZANIg=="
+        },
+        "@storybook/client-logger": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-beta.2.tgz",
+          "integrity": "sha512-6muyKykkS/1G4j7hpnIj0JjubXK9EGxyeqJNEA7dfBWGfJsBzhxISGnaLuAmrG/+RQgjUaGySEVLFxadMrl+DQ==",
+          "requires": {
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/csf-plugin": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-7.0.0-beta.2.tgz",
+          "integrity": "sha512-tAM7gDjl+y3FrqC4rFFsJGEmks12T5BKj63+CMXebydOAsBh67ebc82a+zquG8pRTXVf/qPEeHuf9mNR3+ekzA==",
+          "requires": {
+            "@storybook/csf-tools": "7.0.0-beta.2",
+            "unplugin": "^0.10.2"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.0-beta.2.tgz",
+          "integrity": "sha512-e7qWl1VRy/02o9FmDt8kUg+XTY32pzxs9WFgdhG6gT2tKm5sUPr0UjJr8dab7tC+wH9zBZYNTQgNKPHhKQ0CPQ==",
+          "requires": {
+            "@babel/types": "^7.20.2",
+            "@storybook/csf": "next",
+            "@storybook/types": "7.0.0-beta.2",
+            "fs-extra": "^9.0.1",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.0-beta.2.tgz",
+          "integrity": "sha512-8Gl0cRN8stOa0TvQRH33kfYUC3NfBFogi/VmuJMJKkeYhU9WSvHVc3QvpxoE/ezYVk4D9ECkaaUlVrKpQdh8gQ==",
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.1.0",
+            "npmlog": "^5.0.1",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/types": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-beta.2.tgz",
+          "integrity": "sha512-pNdg0QYSX2UVjAhq5y//vL745wz7qwKX2v2TF17fONvVeO9DPNy7lWUKTG2d7yGWaSb9Nl9jsqi2RWMq8eTDmQ==",
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@storybook/channels": "7.0.0-beta.2",
+            "@types/babel__core": "^7.0.0",
+            "@types/express": "^4.7.0",
+            "express": "^4.17.3",
+            "file-system-cache": "^2.0.0"
+          }
+        },
+        "@types/node": {
+          "version": "16.18.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.7.tgz",
+          "integrity": "sha512-SghuoXv8ghvkrKjTyvhRTeNzivPzGQ8pe09PPGdyqsExiKvBYV/6E3imvjsaJuW8ca61qQN2+SoSzyEHS9r2LA=="
+        },
+        "@vitejs/plugin-react": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
+          "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
+          "requires": {
+            "@babel/core": "^7.19.6",
+            "@babel/plugin-transform-react-jsx": "^7.19.0",
+            "@babel/plugin-transform-react-jsx-development": "^7.18.6",
+            "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+            "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+            "magic-string": "^0.26.7",
+            "react-refresh": "^0.14.0"
+          }
+        },
+        "are-we-there-yet": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "esbuild-darwin-64": {
+          "version": "0.14.54",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+          "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+          "optional": true
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "gauge": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+          "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+          "requires": {
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
+            "signal-exit": "^3.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.2"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "npmlog": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+          "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+          "requires": {
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "rollup": {
+          "version": "2.79.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+          "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        },
+        "vite": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
+          "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+          "requires": {
+            "esbuild": "^0.15.9",
+            "fsevents": "~2.3.2",
+            "postcss": "^8.4.18",
+            "resolve": "^1.22.1",
+            "rollup": "^2.79.1"
+          }
+        }
       }
     },
     "@pixi/storybook-webpack5": {
@@ -23873,6 +25517,23 @@
       "requires": {
         "@pnpm/network.ca-file": "^1.0.1",
         "config-chain": "^1.1.11"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        }
       }
     },
     "@sindresorhus/is": {
@@ -24930,6 +26591,88 @@
       "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-7.0.0-alpha.48.tgz",
       "integrity": "sha512-bvpgvVgi4PXJgxyX210y6s0+oqLVN62vrNrOio4neMF6YhZeLc1M2DCEP2rZBpoQX3dGSSWwjjrCvHSMT5Bp0A=="
     },
+    "@storybook/preview": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.0-beta.2.tgz",
+      "integrity": "sha512-M8gvh7E2VC1dAWuQXdwUQPb89UQaa6PrClmYM4/Aa/mz+SevnAvycmkXzszXf6CMaUAo/wqymyEc4jd9ARXDpQ=="
+    },
+    "@storybook/preview-api": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.0-beta.2.tgz",
+      "integrity": "sha512-c0lXWUxWygqI4Roi+57fMsXab/D1uHKN5pQa66CwflIa41jKJjYGgJrd7RAX3ScSOqZzEk11iwLnZVKkROph/w==",
+      "requires": {
+        "@storybook/channel-postmessage": "7.0.0-beta.2",
+        "@storybook/channels": "7.0.0-beta.2",
+        "@storybook/client-logger": "7.0.0-beta.2",
+        "@storybook/core-events": "7.0.0-beta.2",
+        "@storybook/csf": "next",
+        "@storybook/types": "7.0.0-beta.2",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "slash": "^3.0.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/channel-postmessage": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.0-beta.2.tgz",
+          "integrity": "sha512-a2BkF/4oQ3R+9IfrSjEFvMB91bdISuX/cFEjDMhkAsCSPTInF+8tL3lPi8UT9idLt4lBesoGzP3zkDJHHfYQuA==",
+          "requires": {
+            "@storybook/channels": "7.0.0-beta.2",
+            "@storybook/client-logger": "7.0.0-beta.2",
+            "@storybook/core-events": "7.0.0-beta.2",
+            "global": "^4.4.0",
+            "qs": "^6.10.0",
+            "telejson": "^7.0.3"
+          }
+        },
+        "@storybook/channels": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-beta.2.tgz",
+          "integrity": "sha512-W+kOLjetkfNPpozdE3OXRUp+aKbCJ2t9dIbSked7BOlOtAtKKfQ8F/b12ugGGLpVqo19GdgMPEILOswmeZANIg=="
+        },
+        "@storybook/client-logger": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-beta.2.tgz",
+          "integrity": "sha512-6muyKykkS/1G4j7hpnIj0JjubXK9EGxyeqJNEA7dfBWGfJsBzhxISGnaLuAmrG/+RQgjUaGySEVLFxadMrl+DQ==",
+          "requires": {
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.0-beta.2.tgz",
+          "integrity": "sha512-vA8wuKM2f4A5daannTjiyPCG4vU3zK/VC7HSgL9/gwpzIzDFbQfFYQYTsj5uZN27jPTybys6L62Sw3L0Kpaaig=="
+        },
+        "@storybook/types": {
+          "version": "7.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-beta.2.tgz",
+          "integrity": "sha512-pNdg0QYSX2UVjAhq5y//vL745wz7qwKX2v2TF17fONvVeO9DPNy7lWUKTG2d7yGWaSb9Nl9jsqi2RWMq8eTDmQ==",
+          "requires": {
+            "@babel/core": "^7.12.10",
+            "@storybook/channels": "7.0.0-beta.2",
+            "@types/babel__core": "^7.0.0",
+            "@types/express": "^4.7.0",
+            "express": "^4.17.3",
+            "file-system-cache": "^2.0.0"
+          }
+        },
+        "telejson": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.0.4.tgz",
+          "integrity": "sha512-J4QEuCnYGXAI9KSN7RXK0a0cOW2ONpjc4IQbInGZ6c3stvplLAYyZjTnScrRd8deXVjNCFV1wXcLC7SObDuQYA==",
+          "requires": {
+            "memoizerific": "^1.11.3"
+          }
+        }
+      }
+    },
     "@storybook/preview-web": {
       "version": "7.0.0-alpha.48",
       "resolved": "https://registry.npmjs.org/@storybook/preview-web/-/preview-web-7.0.0-alpha.48.tgz",
@@ -25242,6 +26985,15 @@
         "@types/node": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -25332,8 +27084,7 @@
       "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw=="
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "dev": true
+      "version": "3.0.5"
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -28697,6 +30448,14 @@
         "is-glob": "^4.0.1"
       }
     },
+    "glob-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
+      "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
+      "requires": {
+        "@types/glob": "^7.1.3"
+      }
+    },
     "glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -30186,6 +31945,14 @@
       "version": "6.0.0",
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -32446,6 +34213,11 @@
       "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
     },
+    "react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
+    },
     "read": {
       "version": "1.0.7",
       "dev": true,
@@ -32927,10 +34699,22 @@
       }
     },
     "rollup": {
-      "version": "3.3.0",
-      "dev": true,
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
+      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-external-globals": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.7.1.tgz",
+      "integrity": "sha512-3U2OBhCa/D57P2SA9fx1CGS1xi9h7x7L3+nnAJ0563nIucQysHQdebfKYoI+2WZVkRdVuZKh4M+rgoF0B5W9Ag==",
+      "requires": {
+        "@rollup/pluginutils": "^5.0.2",
+        "estree-walker": "^3.0.1",
+        "is-reference": "^3.0.0",
+        "magic-string": "^0.26.7"
       }
     },
     "rsvp": {
@@ -33614,6 +35398,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "space-separated-tokens": {
       "version": "1.1.5",
@@ -34800,6 +36589,61 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
+      }
+    },
+    "vite": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
+      "integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
+      "requires": {
+        "esbuild": "^0.16.3",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.19",
+        "resolve": "^1.22.1",
+        "rollup": "^3.7.0"
+      },
+      "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+          "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+          "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+          "optional": true
+        },
+        "esbuild": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+          "integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
+          "requires": {
+            "@esbuild/android-arm": "0.16.3",
+            "@esbuild/android-arm64": "0.16.3",
+            "@esbuild/android-x64": "0.16.3",
+            "@esbuild/darwin-arm64": "0.16.3",
+            "@esbuild/darwin-x64": "0.16.3",
+            "@esbuild/freebsd-arm64": "0.16.3",
+            "@esbuild/freebsd-x64": "0.16.3",
+            "@esbuild/linux-arm": "0.16.3",
+            "@esbuild/linux-arm64": "0.16.3",
+            "@esbuild/linux-ia32": "0.16.3",
+            "@esbuild/linux-loong64": "0.16.3",
+            "@esbuild/linux-mips64el": "0.16.3",
+            "@esbuild/linux-ppc64": "0.16.3",
+            "@esbuild/linux-riscv64": "0.16.3",
+            "@esbuild/linux-s390x": "0.16.3",
+            "@esbuild/linux-x64": "0.16.3",
+            "@esbuild/netbsd-x64": "0.16.3",
+            "@esbuild/openbsd-x64": "0.16.3",
+            "@esbuild/sunos-x64": "0.16.3",
+            "@esbuild/win32-arm64": "0.16.3",
+            "@esbuild/win32-ia32": "0.16.3",
+            "@esbuild/win32-x64": "0.16.3"
+          }
+        }
       }
     },
     "walk-up-path": {

--- a/packages/storybook-preset-vite/README.md
+++ b/packages/storybook-preset-vite/README.md
@@ -1,0 +1,3 @@
+# Storybook Vite preset for PixiJS
+
+Storybook PixiJS Vite preset

--- a/packages/storybook-preset-vite/package.json
+++ b/packages/storybook-preset-vite/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@pixi/storybook-preset-vite",
+  "version": "0.0.2",
+  "description": "Storybook for PixiJS: View PixiJS Components in isolation with Hot Reloading.",
+  "homepage": "https://github.com/pixijs/storybook/tree/main/packages/storybook-preset-vite",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/storybook.git",
+    "directory": "packages/storybook-preset-vite"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./preset": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": {
+      "require": "./package.json",
+      "import": "./package.json",
+      "types": "./package.json"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build": "../../scripts/prepare/bundle.ts"
+  },
+  "dependencies": {
+    "@types/node": "^16.0.0",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "vite": "4"
+  },
+  "devDependencies": {
+    "typescript": "~4.6.3"
+  },
+  "peerDependencies": {
+    "@babel/core": "*"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts"
+    ],
+    "platform": "node"
+  }
+}

--- a/packages/storybook-preset-vite/preset.js
+++ b/packages/storybook-preset-vite/preset.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/index");

--- a/packages/storybook-preset-vite/src/index.ts
+++ b/packages/storybook-preset-vite/src/index.ts
@@ -1,0 +1,7 @@
+import type { StorybookConfig } from "./types";
+
+export * from "./types";
+
+export const vite: StorybookConfig["viteFinal"] = (config) => {
+  return config;
+};

--- a/packages/storybook-preset-vite/src/types.ts
+++ b/packages/storybook-preset-vite/src/types.ts
@@ -1,0 +1,4 @@
+export type {
+  TypescriptOptions,
+  StorybookConfig,
+} from "@storybook/builder-vite";

--- a/packages/storybook-preset-vite/tsconfig.json
+++ b/packages/storybook-preset-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/storybook-vite/README.md
+++ b/packages/storybook-vite/README.md
@@ -1,0 +1,3 @@
+# Storybook PixiJS Framework
+
+Storybook PixiJS Framework

--- a/packages/storybook-vite/package.json
+++ b/packages/storybook-vite/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@pixi/storybook-vite",
+  "version": "0.0.2",
+  "description": "Storybook for PixiJS: View Pixi Components in isolation with Hot Reloading.",
+  "homepage": "https://github.com/pixijs/storybook/tree/main/packages/storybook-vite",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/storybook.git",
+    "directory": "packages/storybook-vite"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./preset": {
+      "require": "./dist/preset.js",
+      "import": "./dist/preset.mjs",
+      "types": "./dist/preset.d.ts"
+    },
+    "./package.json": {
+      "require": "./package.json",
+      "import": "./package.json",
+      "types": "./package.json"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build": "../../scripts/prepare/bundle.ts"
+  },
+  "dependencies": {
+    "@pixi/storybook-preset-vite": "^0.0.2",
+    "@pixi/storybook-renderer": "^0.0.2",
+    "@storybook/builder-vite": "^7.0.0-beta.2",
+    "@storybook/core-common": "7.0.0-alpha.48",
+    "@types/node": "^14.14.20 || ^16.0.0",
+    "@types/offscreencanvas": "^2019.7.0",
+    "global": "^4.4.0",
+    "react": "16.14.0",
+    "react-dom": "16.14.0"
+  },
+  "devDependencies": {
+    "typescript": "~4.6.3"
+  },
+  "peerDependencies": {
+    "@babel/core": "*"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts",
+      "./src/preset.ts"
+    ],
+    "platform": "node"
+  }
+}

--- a/packages/storybook-vite/preset.js
+++ b/packages/storybook-vite/preset.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/preset");

--- a/packages/storybook-vite/preview.js
+++ b/packages/storybook-vite/preview.js
@@ -1,0 +1,1 @@
+export * from "./dist/config";

--- a/packages/storybook-vite/src/index.ts
+++ b/packages/storybook-vite/src/index.ts
@@ -1,0 +1,4 @@
+/// <reference types="offscreencanvas" />
+
+export * from "@pixi/storybook-renderer";
+export * from "./types";

--- a/packages/storybook-vite/src/preset.ts
+++ b/packages/storybook-vite/src/preset.ts
@@ -1,0 +1,32 @@
+import path from "path";
+import type { PresetProperty } from "@storybook/types";
+import type { StorybookConfig } from "./types";
+
+export const addons: PresetProperty<"addons", StorybookConfig> = [
+  path.dirname(
+    require.resolve(path.join("@pixi/storybook-preset-vite", "package.json"))
+  ),
+  path.dirname(
+    require.resolve(path.join("@pixi/storybook-renderer", "package.json"))
+  ),
+];
+
+export const core: PresetProperty<"core", StorybookConfig> = async (
+  config,
+  options
+) => {
+  const framework = await options.presets.apply<StorybookConfig["framework"]>(
+    "framework"
+  );
+
+  return {
+    ...config,
+    builder: {
+      name: path.dirname(
+        require.resolve(path.join("@storybook/builder-vite", "package.json"))
+      ) as "@storybook/builder-vite",
+      options:
+        typeof framework === "string" ? {} : framework.options.builder || {},
+    },
+  };
+};

--- a/packages/storybook-vite/src/types.ts
+++ b/packages/storybook-vite/src/types.ts
@@ -1,0 +1,46 @@
+import type {
+  StorybookConfig as StorybookConfigBase,
+  TypescriptOptions as TypescriptOptionsReact,
+} from "@pixi/storybook-preset-vite";
+import type {
+  StorybookConfig as StorybookConfigVite,
+  ViteBuilder as BuilderOptions,
+  TypescriptOptions as TypescriptOptionsBuilder,
+} from "@storybook/builder-vite";
+
+type FrameworkName = "@pixi/storybook-vite";
+type BuilderName = "@storybook/builder-vite";
+
+export type FrameworkOptions = {
+  builder?: BuilderOptions;
+};
+
+type StorybookConfigFramework = {
+  framework:
+    | FrameworkName
+    | {
+        name: FrameworkName;
+        options: FrameworkOptions;
+      };
+  frameworkPath?: string;
+  core?: StorybookConfigBase["core"] & {
+    builder?:
+      | BuilderName
+      | {
+          name: BuilderName;
+          options: BuilderOptions;
+        };
+  };
+  typescript?: Partial<TypescriptOptionsBuilder & TypescriptOptionsReact> &
+    StorybookConfigBase["typescript"];
+};
+
+/**
+ * The interface for Storybook configuration in `main.ts` files.
+ */
+export type StorybookConfig = Omit<
+  StorybookConfigBase,
+  keyof StorybookConfigVite | keyof StorybookConfigFramework
+> &
+  StorybookConfigVite &
+  StorybookConfigFramework;

--- a/packages/storybook-vite/src/typings.d.ts
+++ b/packages/storybook-vite/src/typings.d.ts
@@ -1,0 +1,4 @@
+declare module "global";
+
+// will be provided by the vite define plugin
+declare var NODE_ENV: string | undefined;

--- a/packages/storybook-vite/tsconfig.json
+++ b/packages/storybook-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds support for Vite, closes https://github.com/pixijs/storybook/issues/1.

Created packages for `@pixi/storybook-preset-vite` and `@pixi/storybook-vite` by copying the Webpack ones and modifying them to use Vite.

I've created an example project using this framework here: https://github.com/GregLahaye/pixi-vite-storybook-example.

<img width="787" alt="image" src="https://user-images.githubusercontent.com/16643647/206722682-3da28193-ac95-4269-a9e2-6e8f091d17ee.png">

<img width="957" alt="image" src="https://user-images.githubusercontent.com/16643647/206722851-5b5bc6ff-bf68-45d5-b9d9-94eb027bcf31.png">
