### PR TITLE
Pass instantiated `app` in context pixi parameters

### DIFF
--- a/packages/storybook-renderer/src/render.ts
+++ b/packages/storybook-renderer/src/render.ts
@@ -167,7 +167,7 @@ function removeStory({
 export function renderToDOM(
   {
     storyContext,
-    storyFn,
+    unboundStoryFn,
     kind,
     id,
     name,
@@ -177,10 +177,9 @@ export function renderToDOM(
   }: RenderContext<PixiFramework>,
   domElement: HTMLCanvasElement
 ) {
-  const {
-    parameters: { pixi },
-  } = storyContext;
-  const { applicationOptions, resizeFn = resizeDefault } = pixi;
+  const { parameters } = storyContext;
+  const { pixi: pixiParameters } = parameters;
+  const { applicationOptions, resizeFn = resizeDefault } = pixiParameters;
 
   // Create a new PIXI.Application instance each time applicationOptions changes, ideally
   // applicationOptions is set globally in pixi parameters in `.storybook/preview.ts`, but
@@ -208,7 +207,16 @@ export function renderToDOM(
     storyState = null;
   }
 
-  const storyObject = storyFn();
+  const storyObject = unboundStoryFn({
+    ...storyContext,
+    parameters: {
+      ...parameters,
+      pixi: {
+        ...pixiParameters,
+        app,
+      }
+    }
+  });
   showMain();
 
   if (!storyObject.view) {


### PR DESCRIPTION
This passes the app instance via storybook context inside `parameters.pixi.app` - it relies on `unboundStoryFn` API of storybook, which is currently used by the React renderer itself - however their team said on discord: "No concrete plans [to deprecate `unboundStoryFn`], but it is a blob of code, worthy of cleanup. expected in 8.0 or so."

The potential benefit of doing it like this means that the instantiated app is available inside the story function itself, so can be used before instantiating any story PIXI view elements.

Example usage:

```
export default {
    title: 'Demos-Basic',
    args: {
        bunnySize: 5,
        bunnySpacing: 40,
        someInjectedObject: {
            onBunnyClick: action('onBunnyClick'),
        },
    },
};

export const Default = (args, context) => {
  const { app } = context.parameters.pixi;
  
  // can obviously access app before this
  const view = new Container();
  
  return {
    view,
    // ...etc
  }
}
```