### PR TITLE
Add Vite Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4805,6 +4805,10 @@
         "@pixi/utils": "6.5.9"
       }
     },
+    "node_modules/@pixi/storybook-preset-vite": {
+      "resolved": "packages/storybook-preset-vite",
+      "link": true
+    },
     "node_modules/@pixi/storybook-preset-webpack": {
       "resolved": "packages/storybook-preset-webpack",
       "link": true
@@ -5390,6 +5394,262 @@
       }
     },
     "node_modules/@storybook/builder-manager/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.0.7.tgz",
+      "integrity": "sha512-2wL6fsFWzij+R155urOLc7EjZtlVWf4FLfaSlLGAuZwRQU40N04YdMaHMp9tjd9Vdr5fxEDwTB51PnVWJMlsEw==",
+      "dependencies": {
+        "@storybook/channel-postmessage": "7.0.7",
+        "@storybook/channel-websocket": "7.0.7",
+        "@storybook/client-logger": "7.0.7",
+        "@storybook/core-common": "7.0.7",
+        "@storybook/csf-plugin": "7.0.7",
+        "@storybook/mdx2-csf": "^1.0.0",
+        "@storybook/node-logger": "7.0.7",
+        "@storybook/preview": "7.0.7",
+        "@storybook/preview-api": "7.0.7",
+        "@storybook/types": "7.0.7",
+        "browser-assert": "^1.2.1",
+        "es-module-lexer": "^0.9.3",
+        "express": "^4.17.3",
+        "fs-extra": "^11.1.0",
+        "glob": "^8.1.0",
+        "glob-promise": "^6.0.2",
+        "magic-string": "^0.27.0",
+        "remark-external-links": "^8.0.0",
+        "remark-slug": "^6.0.0",
+        "rollup": "^2.25.0 || ^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@preact/preset-vite": "*",
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0",
+        "vite-plugin-glimmerx": "*"
+      },
+      "peerDependenciesMeta": {
+        "@preact/preset-vite": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-glimmerx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/channel-postmessage": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.7.tgz",
+      "integrity": "sha512-XMtYfcaE0UoY/V7K1cTu9PcWETD4iyWb/Yswc4F9VrPw0Ui4UwGS1j4iaAu8DC06yyoJs4XvxYFBMlCQmKja6A==",
+      "dependencies": {
+        "@storybook/channels": "7.0.7",
+        "@storybook/client-logger": "7.0.7",
+        "@storybook/core-events": "7.0.7",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/channel-websocket": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-7.0.7.tgz",
+      "integrity": "sha512-KDbLiQts4/dCow3qk5WJSPA6SlaX3iP9RhF0Fjj03hoG2TRskrvo+AkUiJr8gF6dpkPndfuCYUCRsO2Ml8B+AA==",
+      "dependencies": {
+        "@storybook/channels": "7.0.7",
+        "@storybook/client-logger": "7.0.7",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/channels": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.7.tgz",
+      "integrity": "sha512-Om4ovBLNw8pVrBu83MpOKgAuGO9Dpr1Coh2qp8t64WRPkejX1mxOY9IgH723//zH3igx8LCkf9rvBvcrsyaScQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/client-logger": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.7.tgz",
+      "integrity": "sha512-EclHjDs5HwHMKB4X2orn/KKA0DTIDmp4AXAUJGRfxb5ArpKEb7tXLHsgrRBlaoz1j5LAwKTmEyZOONh9G3etjg==",
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-common": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.7.tgz",
+      "integrity": "sha512-c8T24wex9bnCYdZVZFNX4VV+wfhrp47OLzVONZDqxMhq6G//Bgv5zH4Awcx5UfWf/05VcP7KGF1VKj8ebRyEEA==",
+      "dependencies": {
+        "@storybook/node-logger": "7.0.7",
+        "@storybook/types": "7.0.7",
+        "@types/node": "^16.0.0",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.17.0",
+        "esbuild-register": "^3.4.0",
+        "file-system-cache": "^2.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^8.1.0",
+        "glob-promise": "^6.0.2",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-events": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.7.tgz",
+      "integrity": "sha512-XNsR2RgaL2vBwuqsu+KA1DzGmB1UFfrAhpxhmyWTKDCniwtTLlaXgfKbqwcrOrPu/o1YswgIup/9UHepRHaf4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-7.0.7.tgz",
+      "integrity": "sha512-uhf2g077gXA6ZEMXIPQ0RnX+IoOTBJbj+6+VQfT7K5tvJeop1z0Fvk0FoknNXcUe7aUA0nzA/cUQ1v4vXqbY3Q==",
+      "dependencies": {
+        "@storybook/csf-tools": "7.0.7",
+        "unplugin": "^0.10.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-tools": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.7.tgz",
+      "integrity": "sha512-KbO5K2RS0oFm94eR49bAPvoyXY3Q6+ozvBek/F05RP7iAV790icQc59Xci9YDM1ONgb3afS+gSJGFBsE0h4pmg==",
+      "dependencies": {
+        "@babel/generator": "~7.21.1",
+        "@babel/parser": "~7.21.2",
+        "@babel/traverse": "~7.21.2",
+        "@babel/types": "~7.21.2",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.0.7",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/node-logger": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.7.tgz",
+      "integrity": "sha512-5Y4LLgKeCStq1ktCKZ5eNPzQQSQ+CYZAlkEdzQ3Pp//0KXaZvVxEvGtaYhAymP2HatLpI8Oneo4lHrJioRfgww==",
+      "dependencies": {
+        "@types/npmlog": "^4.1.2",
+        "chalk": "^4.1.0",
+        "npmlog": "^5.0.1",
+        "pretty-hrtime": "^1.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/preview": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.7.tgz",
+      "integrity": "sha512-uL3ZcFao6UvxiSxCIcXKFakxEr9Nn0lvu0zzC2yQCVepzA7a+GDr1cK5VbZ6Mez38CnOvBmb5pkCbgRqSf/oug==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/preview-api": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.7.tgz",
+      "integrity": "sha512-R5pmGTodpu6hbwEg2RM2ulWtW3d426YzsisHrZJ+FT9lecWauN1y9xHCz7HdNzEFhT8r4YOa24L9ZS3mosZ7hA==",
+      "dependencies": {
+        "@storybook/channel-postmessage": "7.0.7",
+        "@storybook/channels": "7.0.7",
+        "@storybook/client-logger": "7.0.7",
+        "@storybook/core-events": "7.0.7",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "7.0.7",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/types": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.7.tgz",
+      "integrity": "sha512-v9piuwp8FvTiHXIOOi5lEyTEJKhnbcbhVxgJ3VFhhXYFd0DTz6Bst0XIIgkgs21ITb3xhkfPbCRUueMcbXO1MA==",
+      "dependencies": {
+        "@storybook/channels": "7.0.7",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@types/node": {
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
+    },
+    "node_modules/@storybook/builder-vite/node_modules/fs-extra": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
@@ -13309,6 +13569,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16159,9 +16430,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
       "funding": [
         {
           "type": "opencollective",
@@ -16170,10 +16441,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -17398,10 +17673,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
-      "dev": true,
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.3.tgz",
+      "integrity": "sha512-VnPfEG51nIv2xPLnZaekkuN06q9ZbnyDcLkaBdJa/W7UddyhOfMP2yOPziYQfeY7k++fZM8FdQIummFN5y14kA==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19282,6 +19556,54 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.4.tgz",
+      "integrity": "sha512-f90aqGBoxSFxWph2b39ae2uHAxm5jFBBdnfueNxZAT1FTpM13ccFQExCaKbR2xFW5atowjleRniQ7onjJ22QEg==",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.17.5",
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
@@ -19791,6 +20113,27 @@
         "pixi.js": "^6.3.0",
         "storybook": "~7.0.0-beta"
       }
+    },
+    "packages/storybook-preset-vite": {
+      "version": "0.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/builder-vite": "^7.0.0",
+        "@types/node": "^16.0.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
+      },
+      "devDependencies": {
+        "typescript": "~4.6.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "packages/storybook-preset-vite/node_modules/@types/node": {
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
     },
     "packages/storybook-preset-webpack": {
       "name": "@pixi/storybook-preset-webpack",
@@ -23206,6 +23549,23 @@
       "integrity": "sha512-jf27xXl1/v2kA+Vr8E4/xLAMMO3xxNOk/blZCVr/RwKILS9T3R1Y7f4FICW2Gv4jLreBLvWwYM41NPon9/N3/g==",
       "requires": {}
     },
+    "@pixi/storybook-preset-vite": {
+      "version": "file:packages/storybook-preset-vite",
+      "requires": {
+        "@storybook/builder-vite": "^7.0.0",
+        "@types/node": "^16.0.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "typescript": "~4.6.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+          "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
+        }
+      }
+    },
     "@pixi/storybook-preset-webpack": {
       "version": "file:packages/storybook-preset-webpack",
       "requires": {
@@ -23607,6 +23967,192 @@
         "util": "^0.12.4"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@storybook/builder-vite": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.0.7.tgz",
+      "integrity": "sha512-2wL6fsFWzij+R155urOLc7EjZtlVWf4FLfaSlLGAuZwRQU40N04YdMaHMp9tjd9Vdr5fxEDwTB51PnVWJMlsEw==",
+      "requires": {
+        "@storybook/channel-postmessage": "7.0.7",
+        "@storybook/channel-websocket": "7.0.7",
+        "@storybook/client-logger": "7.0.7",
+        "@storybook/core-common": "7.0.7",
+        "@storybook/csf-plugin": "7.0.7",
+        "@storybook/mdx2-csf": "^1.0.0",
+        "@storybook/node-logger": "7.0.7",
+        "@storybook/preview": "7.0.7",
+        "@storybook/preview-api": "7.0.7",
+        "@storybook/types": "7.0.7",
+        "browser-assert": "^1.2.1",
+        "es-module-lexer": "^0.9.3",
+        "express": "^4.17.3",
+        "fs-extra": "^11.1.0",
+        "glob": "^8.1.0",
+        "glob-promise": "^6.0.2",
+        "magic-string": "^0.27.0",
+        "remark-external-links": "^8.0.0",
+        "remark-slug": "^6.0.0",
+        "rollup": "^2.25.0 || ^3.3.0"
+      },
+      "dependencies": {
+        "@storybook/channel-postmessage": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.7.tgz",
+          "integrity": "sha512-XMtYfcaE0UoY/V7K1cTu9PcWETD4iyWb/Yswc4F9VrPw0Ui4UwGS1j4iaAu8DC06yyoJs4XvxYFBMlCQmKja6A==",
+          "requires": {
+            "@storybook/channels": "7.0.7",
+            "@storybook/client-logger": "7.0.7",
+            "@storybook/core-events": "7.0.7",
+            "@storybook/global": "^5.0.0",
+            "qs": "^6.10.0",
+            "telejson": "^7.0.3"
+          }
+        },
+        "@storybook/channel-websocket": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-7.0.7.tgz",
+          "integrity": "sha512-KDbLiQts4/dCow3qk5WJSPA6SlaX3iP9RhF0Fjj03hoG2TRskrvo+AkUiJr8gF6dpkPndfuCYUCRsO2Ml8B+AA==",
+          "requires": {
+            "@storybook/channels": "7.0.7",
+            "@storybook/client-logger": "7.0.7",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.0.3"
+          }
+        },
+        "@storybook/channels": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.7.tgz",
+          "integrity": "sha512-Om4ovBLNw8pVrBu83MpOKgAuGO9Dpr1Coh2qp8t64WRPkejX1mxOY9IgH723//zH3igx8LCkf9rvBvcrsyaScQ=="
+        },
+        "@storybook/client-logger": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.7.tgz",
+          "integrity": "sha512-EclHjDs5HwHMKB4X2orn/KKA0DTIDmp4AXAUJGRfxb5ArpKEb7tXLHsgrRBlaoz1j5LAwKTmEyZOONh9G3etjg==",
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.7.tgz",
+          "integrity": "sha512-c8T24wex9bnCYdZVZFNX4VV+wfhrp47OLzVONZDqxMhq6G//Bgv5zH4Awcx5UfWf/05VcP7KGF1VKj8ebRyEEA==",
+          "requires": {
+            "@storybook/node-logger": "7.0.7",
+            "@storybook/types": "7.0.7",
+            "@types/node": "^16.0.0",
+            "@types/pretty-hrtime": "^1.0.0",
+            "chalk": "^4.1.0",
+            "esbuild": "^0.17.0",
+            "esbuild-register": "^3.4.0",
+            "file-system-cache": "^2.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^8.1.0",
+            "glob-promise": "^6.0.2",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.7.tgz",
+          "integrity": "sha512-XNsR2RgaL2vBwuqsu+KA1DzGmB1UFfrAhpxhmyWTKDCniwtTLlaXgfKbqwcrOrPu/o1YswgIup/9UHepRHaf4A=="
+        },
+        "@storybook/csf-plugin": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-7.0.7.tgz",
+          "integrity": "sha512-uhf2g077gXA6ZEMXIPQ0RnX+IoOTBJbj+6+VQfT7K5tvJeop1z0Fvk0FoknNXcUe7aUA0nzA/cUQ1v4vXqbY3Q==",
+          "requires": {
+            "@storybook/csf-tools": "7.0.7",
+            "unplugin": "^0.10.2"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.7.tgz",
+          "integrity": "sha512-KbO5K2RS0oFm94eR49bAPvoyXY3Q6+ozvBek/F05RP7iAV790icQc59Xci9YDM1ONgb3afS+gSJGFBsE0h4pmg==",
+          "requires": {
+            "@babel/generator": "~7.21.1",
+            "@babel/parser": "~7.21.2",
+            "@babel/traverse": "~7.21.2",
+            "@babel/types": "~7.21.2",
+            "@storybook/csf": "^0.1.0",
+            "@storybook/types": "7.0.7",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.1",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.7.tgz",
+          "integrity": "sha512-5Y4LLgKeCStq1ktCKZ5eNPzQQSQ+CYZAlkEdzQ3Pp//0KXaZvVxEvGtaYhAymP2HatLpI8Oneo4lHrJioRfgww==",
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.1.0",
+            "npmlog": "^5.0.1",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/preview": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.7.tgz",
+          "integrity": "sha512-uL3ZcFao6UvxiSxCIcXKFakxEr9Nn0lvu0zzC2yQCVepzA7a+GDr1cK5VbZ6Mez38CnOvBmb5pkCbgRqSf/oug=="
+        },
+        "@storybook/preview-api": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.7.tgz",
+          "integrity": "sha512-R5pmGTodpu6hbwEg2RM2ulWtW3d426YzsisHrZJ+FT9lecWauN1y9xHCz7HdNzEFhT8r4YOa24L9ZS3mosZ7hA==",
+          "requires": {
+            "@storybook/channel-postmessage": "7.0.7",
+            "@storybook/channels": "7.0.7",
+            "@storybook/client-logger": "7.0.7",
+            "@storybook/core-events": "7.0.7",
+            "@storybook/csf": "^0.1.0",
+            "@storybook/global": "^5.0.0",
+            "@storybook/types": "7.0.7",
+            "@types/qs": "^6.9.5",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "synchronous-promise": "^2.0.15",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-v9piuwp8FvTiHXIOOi5lEyTEJKhnbcbhVxgJ3VFhhXYFd0DTz6Bst0XIIgkgs21ITb3xhkfPbCRUueMcbXO1MA==",
+          "requires": {
+            "@storybook/channels": "7.0.7",
+            "@types/babel__core": "^7.0.0",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "^2.0.0"
+          }
+        },
+        "@types/node": {
+          "version": "16.18.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+          "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
+        },
         "fs-extra": {
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -29719,6 +30265,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -31922,11 +32476,11 @@
       }
     },
     "postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -32834,10 +33388,9 @@
       }
     },
     "rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
-      "dev": true,
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.3.tgz",
+      "integrity": "sha512-VnPfEG51nIv2xPLnZaekkuN06q9ZbnyDcLkaBdJa/W7UddyhOfMP2yOPziYQfeY7k++fZM8FdQIummFN5y14kA==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -34232,6 +34785,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "vite": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.4.tgz",
+      "integrity": "sha512-f90aqGBoxSFxWph2b39ae2uHAxm5jFBBdnfueNxZAT1FTpM13ccFQExCaKbR2xFW5atowjleRniQ7onjJ22QEg==",
+      "peer": true,
+      "requires": {
+        "esbuild": "^0.17.5",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
+      }
     },
     "walk-up-path": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4817,6 +4817,10 @@
       "resolved": "packages/storybook-renderer",
       "link": true
     },
+    "node_modules/@pixi/storybook-vite": {
+      "resolved": "packages/storybook-vite",
+      "link": true
+    },
     "node_modules/@pixi/storybook-webpack5": {
       "resolved": "packages/storybook-webpack5",
       "link": true
@@ -20115,10 +20119,12 @@
       }
     },
     "packages/storybook-preset-vite": {
+      "name": "@pixi/storybook-preset-vite",
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@storybook/builder-vite": "^7.0.0",
+        "@storybook/types": "^7.0.0",
         "@types/node": "^16.0.0",
         "react": "16.14.0",
         "react-dom": "16.14.0"
@@ -20191,6 +20197,33 @@
         "@babel/core": "*",
         "pixi.js": ">6.0.0"
       }
+    },
+    "packages/storybook-vite": {
+      "name": "@pixi/storybook-vite",
+      "version": "0.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/storybook-preset-vite": "^0.0.6",
+        "@pixi/storybook-renderer": "^0.0.6",
+        "@storybook/builder-vite": "^7.0.0",
+        "@storybook/core-common": "^7.0.0",
+        "@types/node": "^14.14.20 || ^16.0.0",
+        "@types/offscreencanvas": "^2019.7.0",
+        "global": "^4.4.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
+      },
+      "devDependencies": {
+        "typescript": "~4.6.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "packages/storybook-vite/node_modules/@types/node": {
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
     },
     "packages/storybook-webpack5": {
       "name": "@pixi/storybook-webpack5",
@@ -23553,6 +23586,7 @@
       "version": "file:packages/storybook-preset-vite",
       "requires": {
         "@storybook/builder-vite": "^7.0.0",
+        "@storybook/types": "^7.0.0",
         "@types/node": "^16.0.0",
         "react": "16.14.0",
         "react-dom": "16.14.0",
@@ -23602,6 +23636,28 @@
         "react-dom": "16.14.0",
         "ts-dedent": "^2.0.0",
         "typescript": "~4.6.3"
+      }
+    },
+    "@pixi/storybook-vite": {
+      "version": "file:packages/storybook-vite",
+      "requires": {
+        "@pixi/storybook-preset-vite": "^0.0.6",
+        "@pixi/storybook-renderer": "^0.0.6",
+        "@storybook/builder-vite": "^7.0.0",
+        "@storybook/core-common": "^7.0.0",
+        "@types/node": "^14.14.20 || ^16.0.0",
+        "@types/offscreencanvas": "^2019.7.0",
+        "global": "^4.4.0",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "typescript": "~4.6.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+          "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
+        }
       }
     },
     "@pixi/storybook-webpack5": {

--- a/packages/storybook-preset-vite/README.md
+++ b/packages/storybook-preset-vite/README.md
@@ -1,0 +1,3 @@
+# Storybook Vite preset for PixiJS
+
+Storybook PixiJS Vite preset

--- a/packages/storybook-preset-vite/package.json
+++ b/packages/storybook-preset-vite/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@storybook/builder-vite": "^7.0.0",
+    "@storybook/types": "^7.0.0",
     "@types/node": "^16.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0"

--- a/packages/storybook-preset-vite/package.json
+++ b/packages/storybook-preset-vite/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@pixi/storybook-preset-vite",
+  "version": "0.0.6",
+  "description": "Storybook for PixiJS: View PixiJS Components in isolation with Hot Reloading.",
+  "homepage": "https://github.com/pixijs/storybook/tree/main/packages/storybook-preset-vite",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/storybook.git",
+    "directory": "packages/storybook-preset-vite"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./preset": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": {
+      "require": "./package.json",
+      "import": "./package.json",
+      "types": "./package.json"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build": "../../scripts/prepare/bundle.ts"
+  },
+  "dependencies": {
+    "@storybook/builder-vite": "^7.0.0",
+    "@types/node": "^16.0.0",
+    "react": "16.14.0",
+    "react-dom": "16.14.0"
+  },
+  "devDependencies": {
+    "typescript": "~4.6.3"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts"
+    ],
+    "platform": "node"
+  }
+}

--- a/packages/storybook-preset-vite/preset.js
+++ b/packages/storybook-preset-vite/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/index');

--- a/packages/storybook-preset-vite/src/index.ts
+++ b/packages/storybook-preset-vite/src/index.ts
@@ -1,0 +1,7 @@
+import type { StorybookConfigVite } from "./types";
+
+export * from "./types";
+
+export const webpack: StorybookConfigVite["viteFinal"] = (config) => {
+  return config;
+};

--- a/packages/storybook-preset-vite/src/index.ts
+++ b/packages/storybook-preset-vite/src/index.ts
@@ -2,6 +2,6 @@ import type { StorybookConfigVite } from "./types";
 
 export * from "./types";
 
-export const webpack: StorybookConfigVite["viteFinal"] = (config) => {
+export const vite: StorybookConfigVite["viteFinal"] = (config) => {
   return config;
 };

--- a/packages/storybook-preset-vite/src/types.ts
+++ b/packages/storybook-preset-vite/src/types.ts
@@ -1,0 +1,5 @@
+export type {
+  ViteBuilder,
+  BuilderOptions,
+  StorybookConfigVite,
+} from "@storybook/builder-vite";

--- a/packages/storybook-preset-vite/src/types.ts
+++ b/packages/storybook-preset-vite/src/types.ts
@@ -1,5 +1,5 @@
 export type {
-  ViteBuilder,
-  BuilderOptions,
   StorybookConfigVite,
+  BuilderOptions,
 } from "@storybook/builder-vite";
+export type { StorybookConfig, TypescriptOptions } from "@storybook/types";

--- a/packages/storybook-preset-vite/tsconfig.json
+++ b/packages/storybook-preset-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*"],
+}

--- a/packages/storybook-vite/README.md
+++ b/packages/storybook-vite/README.md
@@ -1,0 +1,3 @@
+# Storybook PixiJS Framework
+
+Storybook PixiJS Framework

--- a/packages/storybook-vite/package.json
+++ b/packages/storybook-vite/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@pixi/storybook-vite",
+  "version": "0.0.6",
+  "description": "Storybook for PixiJS: View Pixi Components in isolation with Hot Reloading.",
+  "homepage": "https://github.com/pixijs/storybook/tree/main/packages/storybook-vite",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/storybook.git",
+    "directory": "packages/storybook-vite"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./preset": {
+      "require": "./dist/preset.js",
+      "import": "./dist/preset.mjs",
+      "types": "./dist/preset.d.ts"
+    },
+    "./package.json": {
+      "require": "./package.json",
+      "import": "./package.json",
+      "types": "./package.json"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build": "../../scripts/prepare/bundle.ts"
+  },
+  "dependencies": {
+    "@pixi/storybook-preset-vite": "^0.0.6",
+    "@pixi/storybook-renderer": "^0.0.6",
+    "@storybook/builder-vite": "^7.0.0",
+    "@storybook/core-common": "^7.0.0",
+    "@types/node": "^14.14.20 || ^16.0.0",
+    "@types/offscreencanvas": "^2019.7.0",
+    "global": "^4.4.0",
+    "react": "16.14.0",
+    "react-dom": "16.14.0"
+  },
+  "devDependencies": {
+    "typescript": "~4.6.3"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts",
+      "./src/preset.ts"
+    ],
+    "platform": "node"
+  }
+}

--- a/packages/storybook-vite/preset.js
+++ b/packages/storybook-vite/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/preset');

--- a/packages/storybook-vite/preview.js
+++ b/packages/storybook-vite/preview.js
@@ -1,0 +1,1 @@
+export * from './dist/config';

--- a/packages/storybook-vite/src/index.ts
+++ b/packages/storybook-vite/src/index.ts
@@ -1,0 +1,4 @@
+/// <reference types="offscreencanvas" />
+
+export * from '@pixi/storybook-renderer';
+export * from './types';

--- a/packages/storybook-vite/src/preset.ts
+++ b/packages/storybook-vite/src/preset.ts
@@ -1,0 +1,32 @@
+import path from "path";
+import type { PresetProperty } from "@storybook/types";
+import type { StorybookConfig } from "./types";
+
+export const addons: PresetProperty<"addons", StorybookConfig> = [
+  path.dirname(
+    require.resolve(path.join("@pixi/storybook-preset-vite", "package.json"))
+  ),
+  path.dirname(
+    require.resolve(path.join("@pixi/storybook-renderer", "package.json"))
+  ),
+];
+
+export const core: PresetProperty<"core", StorybookConfig> = async (
+  config,
+  options
+) => {
+  const framework = await options.presets.apply<StorybookConfig["framework"]>(
+    "framework"
+  );
+
+  return {
+    ...config,
+    builder: {
+      name: path.dirname(
+        require.resolve(path.join("@storybook/builder-vite", "package.json"))
+      ) as "@storybook/builder-vite",
+      options:
+        typeof framework === "string" ? {} : framework.options.builder || {},
+    },
+  };
+};

--- a/packages/storybook-vite/src/types.ts
+++ b/packages/storybook-vite/src/types.ts
@@ -1,0 +1,43 @@
+import type {
+  BuilderOptions,
+  StorybookConfig as StorybookConfigBase,
+  StorybookConfigVite,
+  TypescriptOptions as TypescriptOptionsBuilder,
+} from "../../storybook-preset-vite/src/types";
+
+type FrameworkName = "@pixi/storybook-vite";
+type BuilderName = "@storybook/builder-vite";
+
+export type FrameworkOptions = {
+  builder?: BuilderOptions;
+};
+
+type StorybookConfigFramework = {
+  framework:
+    | FrameworkName
+    | {
+        name: FrameworkName;
+        options: FrameworkOptions;
+      };
+  frameworkPath?: string;
+  core?: StorybookConfigBase["core"] & {
+    builder?:
+      | BuilderName
+      | {
+          name: BuilderName;
+          options: BuilderOptions;
+        };
+  };
+  typescript?: Partial<TypescriptOptionsBuilder> &
+    StorybookConfigBase["typescript"];
+};
+
+/**
+ * The interface for Storybook configuration in `main.ts` files.
+ */
+export type StorybookConfig = Omit<
+  StorybookConfigBase,
+  keyof StorybookConfigVite | keyof StorybookConfigFramework
+> &
+  StorybookConfigVite &
+  StorybookConfigFramework;

--- a/packages/storybook-vite/tsconfig.json
+++ b/packages/storybook-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*"],
+}


### PR DESCRIPTION
Adds support for Vite, closes https://github.com/pixijs/storybook/issues/1.

Created packages for `@pixi/storybook-preset-vite` and `@pixi/storybook-vite` by copying the Webpack ones and modifying them to use Vite.

![image](https://user-images.githubusercontent.com/97146144/235818664-bbb9593c-fb58-4b3f-9843-1398e5d68d9b.png)

Screenshot from example repo: https://github.com/GregVGW/pixi-storybook-playground

Have also tried this out in some other projects.