### PR TITLE
Build with pixi.js-legacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,10 +4290,495 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pixi/accessibility": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
+      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
+      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-display": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-display/-/canvas-display-6.5.10.tgz",
+      "integrity": "sha512-pT0uhEoy24ei/5JwCYgpf+4A5vP8X5zFICJJOm2bE0k/veLc/nIpHj8SL3jG4CDmYGNAntVodEy+/E23HfzZxQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/display": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-extract": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-extract/-/canvas-extract-6.5.10.tgz",
+      "integrity": "sha512-HEgZYvomZx3slLUDbX/tyn2+x8PprFUI5FdRHIN72uED34O09RrbvtQgymrCJCs/aZg+cxd85LRdmNIBn/LyLA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-graphics": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-graphics/-/canvas-graphics-6.5.10.tgz",
+      "integrity": "sha512-y/CabuQE9pJLkVx8UBvU40bKuRvkSPwsZjjFBxdz7JHruRfN4jh6MCYL6ZbAsy+4HT++btrJaY4f56ykGzX8+g==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-display": "6.5.10",
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-mesh": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-mesh/-/canvas-mesh-6.5.10.tgz",
+      "integrity": "sha512-B3JeiOObiYi6Jhq+4M+FxEUjdwjUeaD7EGvMBgcHIGFJ9QRv6maogHUz8SlC117jGKl4lIVUFYlX4MAyuBnT9g==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-display": "6.5.10",
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-particle-container": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-particle-container/-/canvas-particle-container-6.5.10.tgz",
+      "integrity": "sha512-e86tYlaBWcIO7ZZdX3TAPCw4kOpd+6JMgz3W/pKckAEYKcNNdSjxMRStzVRjdflaQbjPQKjqIAFB1zAGMHHxxA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/particle-container": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-prepare": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-prepare/-/canvas-prepare-6.5.10.tgz",
+      "integrity": "sha512-z2VQ7FJ/VaX3m2MWBGZFmWY5yQVwKhxqErtTvrPn7BYkQ4gIGn8VIWnj5CI/xQiohx53ONjAxkSNm2QIyl6Zkg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-renderer": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.5.10.tgz",
+      "integrity": "sha512-DzRJLtjt4fuxMj8kgwBxJgmdf3hmuzC8nTElEHbDH07FbVJSwD9GzNIxFli82jrKUo1nyMBoI4bUU+D+MOhAFw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-sprite": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite/-/canvas-sprite-6.5.10.tgz",
+      "integrity": "sha512-CcgBvKfuXoYOU8kMFxaaIZq8/+sFtX7PmiLzsgksxu40d6zAF3o1FFQBd0CDAUPB/9G4/3ebpeDW5eKX8hV9hA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-display": "6.5.10",
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-sprite-tiling": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite-tiling/-/canvas-sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-dHiRvwmEJqxVgIDnxj8edfi2OJuaS267P8DpKhRG+37O0A5Cx0Q9M9qHOh72f1TV44o4s2O8zcq97R9n9eQZ1Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/canvas-sprite": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/canvas-text": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-text/-/canvas-text-6.5.10.tgz",
+      "integrity": "sha512-RmPLMkrA10do+fpsPZC1dBeqM/JWRf4CsHjcOjsKQU9uqN04vFLo8qPFarTWYgjr304ACWeJyd9rVbDrOYKK2Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/canvas-sprite": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/text": "6.5.10"
+      }
+    },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
+      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
+      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
+      "dev": true
+    },
+    "node_modules/@pixi/core": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
+      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
+      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
+      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/extract": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
+      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
+      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
+      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
+      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
+      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
+      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
+      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
+      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/interaction": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
+      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/loaders": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
+      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
+      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
+      "dev": true
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
+      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
+      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
+      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
+      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/display": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
+      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
+      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/polyfill": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
+      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
+      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
+      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
+      "dev": true
+    },
+    "node_modules/@pixi/settings": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
+      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
+      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
+      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/ticker": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
+      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
     },
     "node_modules/@pixi/storybook-preset-webpack": {
       "resolved": "packages/storybook-preset-webpack",
@@ -4306,6 +4791,68 @@
     "node_modules/@pixi/storybook-webpack5": {
       "resolved": "packages/storybook-webpack5",
       "link": true
+    },
+    "node_modules/@pixi/text": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
+      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
+      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
+      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/extensions": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
+      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "dev": true,
+      "dependencies": {
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "node_modules/@pixi/utils/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -16927,6 +17474,77 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pixi.js": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
+      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/accessibility": "6.5.10",
+        "@pixi/app": "6.5.10",
+        "@pixi/compressed-textures": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/extract": "6.5.10",
+        "@pixi/filter-alpha": "6.5.10",
+        "@pixi/filter-blur": "6.5.10",
+        "@pixi/filter-color-matrix": "6.5.10",
+        "@pixi/filter-displacement": "6.5.10",
+        "@pixi/filter-fxaa": "6.5.10",
+        "@pixi/filter-noise": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/interaction": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/mixin-cache-as-bitmap": "6.5.10",
+        "@pixi/mixin-get-child-by-name": "6.5.10",
+        "@pixi/mixin-get-global-position": "6.5.10",
+        "@pixi/particle-container": "6.5.10",
+        "@pixi/polyfill": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/sprite-animated": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/spritesheet": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/text-bitmap": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/pixi.js-legacy": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js-legacy/-/pixi.js-legacy-6.5.10.tgz",
+      "integrity": "sha512-oHek4uF/McnZTHCiEQj8QxP7ibA1+DaSVuhlAV46GBpCfyBq7E5EDcabMvFdSFjeIcVyMfUfMTiuVxR0JFBNbg==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/canvas-display": "6.5.10",
+        "@pixi/canvas-extract": "6.5.10",
+        "@pixi/canvas-graphics": "6.5.10",
+        "@pixi/canvas-mesh": "6.5.10",
+        "@pixi/canvas-particle-container": "6.5.10",
+        "@pixi/canvas-prepare": "6.5.10",
+        "@pixi/canvas-renderer": "6.5.10",
+        "@pixi/canvas-sprite": "6.5.10",
+        "@pixi/canvas-sprite-tiling": "6.5.10",
+        "@pixi/canvas-text": "6.5.10",
+        "pixi.js": "6.5.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
@@ -17194,6 +17812,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
       "dev": true
     },
     "node_modules/promise-retry": {
@@ -21435,7 +22059,7 @@
       "devDependencies": {
         "@types/deep-equal": "^1.0.4",
         "@types/webpack-env": "^1.18.4",
-        "pixi.js": "^8.0.0",
+        "pixi.js-legacy": "^6.3.0",
         "typescript": "~5.3.3"
       },
       "engines": {
@@ -21443,30 +22067,7 @@
       },
       "peerDependencies": {
         "@babel/core": "*",
-        "pixi.js": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "packages/storybook-renderer/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
-    },
-    "packages/storybook-renderer/node_modules/pixi.js": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.0.tgz",
-      "integrity": "sha512-MX8cNEomyluT6EwVinMY+AKW37AKIDFi0DPWvQ59vU1P8jZpKy/tj+uyns8iyjK+F5wtc04AF/p9CH03iAO2lw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/colord": "^2.9.6",
-        "@types/css-font-loading-module": "^0.0.12",
-        "@types/earcut": "^2.1.4",
-        "@webgpu/types": "^0.1.40",
-        "@xmldom/xmldom": "^0.8.10",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^5.0.1",
-        "ismobilejs": "^1.1.1",
-        "parse-svg-path": "^0.1.2"
+        "pixi.js-legacy": "^6.3.0"
       }
     },
     "packages/storybook-webpack5": {

--- a/packages/storybook-renderer/package.json
+++ b/packages/storybook-renderer/package.json
@@ -53,12 +53,12 @@
   "devDependencies": {
     "@types/deep-equal": "^1.0.4",
     "@types/webpack-env": "^1.18.4",
-    "pixi.js": "^8.0.0",
+    "pixi.js-legacy": "^6.3.0",
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
     "@babel/core": "*",
-    "pixi.js": "^7.0.0 || ^8.0.0"
+    "pixi.js-legacy": "^6.3.0"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/storybook-renderer/src/helpers/PixiStory.ts
+++ b/packages/storybook-renderer/src/helpers/PixiStory.ts
@@ -1,4 +1,4 @@
-import { Container, Ticker } from 'pixi.js';
+import { Container, Ticker } from 'pixi.js-legacy';
 import { StoryFn } from '../types/public-types';
 
 export class PixiStory<Args> {

--- a/packages/storybook-renderer/src/render.ts
+++ b/packages/storybook-renderer/src/render.ts
@@ -1,6 +1,6 @@
 import equals from 'deep-equal';
-import type { ApplicationOptions } from 'pixi.js';
-import { Application, Ticker } from 'pixi.js';
+import type { IApplicationOptions as ApplicationOptions } from 'pixi.js-legacy';
+import { Application, Ticker } from 'pixi.js-legacy';
 
 import type { RenderContext } from '@storybook/types';
 import { dedent } from 'ts-dedent';
@@ -63,14 +63,8 @@ function getPixiApplication(applicationOptions: ApplicationOptions): Application
       pixiApp.destroy(true);
     }
 
-    // check if Application has init method
-    if (!Application.prototype.init) {
-      pixiApp = new Application({ ...applicationOptions, view: canvas });
-      appReady = Promise.resolve();
-    } else {
-      pixiApp = new Application();
-      appReady = pixiApp.init({ ...applicationOptions, canvas });
-    }
+    pixiApp = new Application({ ...applicationOptions, view: canvas });
+    appReady = Promise.resolve();
 
     lastApplicationOptions = applicationOptions;
   }
@@ -170,7 +164,9 @@ function addStory({
 
   if (storyObject.update) {
     updateRef = updater();
-    Ticker.shared.add(storyObject.update, updateRef);
+    app.ticker.add(() => {
+      storyObject.update && storyObject.update(app.ticker);
+    }, updateRef);
   }
 
   return storyResizeHandler;
@@ -186,7 +182,9 @@ function removeStory({
   storyResizeHandler: EventHandler;
 }) {
   if (storyObject.update) {
-    Ticker.shared.remove(storyObject.update, updateRef);
+    Ticker.shared.remove(() => {
+      storyObject.update && storyObject.update(app.ticker);
+    }, updateRef);
   }
 
   app.stage.removeChild(storyObject.view);

--- a/packages/storybook-renderer/src/types/types.ts
+++ b/packages/storybook-renderer/src/types/types.ts
@@ -1,6 +1,6 @@
 import type { StoryContext as DefaultStoryContext } from '@storybook/csf';
 import { Renderer } from '@storybook/types';
-import { Application, ApplicationOptions, Container, Ticker } from 'pixi.js';
+import { Application, IApplicationOptions as ApplicationOptions, Container, Ticker } from 'pixi.js-legacy';
 
 export type { RenderContext } from '@storybook/types';
 


### PR DESCRIPTION
Opening this PR only to reference my work, it can be helpful to someone else running legacy.

With these small changes, I was able to use it with `pixi.js-legacy`.

Closing it because I don't expect it to be merged.