### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "slash": "^3.0.0",
     "execa": "^5.0.0",
     "chalk": "^4.1.0"
+  },
+  "bugs": {
+    "url": "https://github.com/pixijs/storybook/issues"
   }
 }


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.